### PR TITLE
Remove line comment configuration

### DIFF
--- a/postcss.configuration.json
+++ b/postcss.configuration.json
@@ -1,7 +1,5 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
PostCSS does not support line comments. VSCode was trying to comment using `//` but that syntax is not valid.